### PR TITLE
Add Pulumi workshop starter project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+bin
+.DS_Store
+app/node_modules

--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: workshop-sample
+runtime: nodejs
+description: Sample Pulumi project for OpenShift workshop

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# IaC
-IaC for devops 
+# IaC Workshop Sample
+
+This repository contains a basic Pulumi project that deploys a simple Node.js
+form application backed by Postgres to an OpenShift cluster. Each student
+deploys the application into their own namespace using Pulumi.
+
+## Requirements
+
+- Node.js and npm
+- Pulumi CLI
+- Access to an OpenShift cluster with permissions to create namespaces
+- Docker installed and access to a container registry to push images
+
+## Quick Start
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Configure your Pulumi stack. Replace `student01` with your assigned
+   namespace and provide Docker registry credentials so Pulumi can push the
+   application image.
+
+   ```bash
+   pulumi stack init dev    # if creating a new stack
+   pulumi config set studentNamespace student01
+   pulumi config set appImage <registry>/sample-form-app:latest
+   pulumi config set registry.username <registry-user>
+   pulumi config set --secret registry.password <registry-password>
+   pulumi config set --secret dbPassword <db-password>   # optional
+   ```
+
+3. Deploy:
+   ```bash
+   pulumi up
+   ```
+
+4. After deployment completes, Pulumi will output the route URL. Visit this URL
+   in your browser to see the form application.
+
+## Application
+
+The application source is in the `app/` directory. It is a small Express server
+that stores submitted names in Postgres and displays the list of entries.
+Pulumi builds a Docker image from this directory and pushes it to the registry
+specified in the Pulumi configuration.

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const { Pool } = require('pg');
+
+const app = express();
+app.use(bodyParser.urlencoded({ extended: false }));
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER || 'user',
+  password: process.env.DB_PASS || 'password',
+  database: process.env.DB_NAME || 'students',
+});
+
+async function init() {
+  await pool.query('CREATE TABLE IF NOT EXISTS entries (id SERIAL PRIMARY KEY, name TEXT, created_at TIMESTAMP DEFAULT now())');
+}
+
+app.get('/', (req, res) => {
+  res.send(`<!DOCTYPE html>
+<html>
+<head><title>Sample Form</title></head>
+<body>
+<h1>Sample Form</h1>
+<form action="/submit" method="POST">
+  <input name="name" placeholder="Your name" />
+  <button type="submit">Submit</button>
+</form>
+<a href="/entries">View entries</a>
+</body>
+</html>`);
+});
+
+app.post('/submit', async (req, res) => {
+  const name = req.body.name;
+  if (name) {
+    await pool.query('INSERT INTO entries(name) VALUES($1)', [name]);
+  }
+  res.redirect('/entries');
+});
+
+app.get('/entries', async (req, res) => {
+  const result = await pool.query('SELECT name, created_at FROM entries ORDER BY id DESC');
+  const list = result.rows.map(r => `<li>${r.name} (${r.created_at.toISOString()})</li>`).join('');
+  res.send(`<!DOCTYPE html>
+<html>
+<head><title>Entries</title></head>
+<body>
+<h1>Entries</h1>
+<ul>${list}</ul>
+<a href="/">Go back</a>
+</body>
+</html>`);
+});
+
+init().then(() => {
+  app.listen(8080, () => console.log('Server running on 8080'));
+}).catch(err => {
+  console.error('Failed to init DB', err);
+  process.exit(1);
+});

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sample-form-app",
+  "version": "1.0.0",
+  "description": "Simple Express form app with Postgres",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2",
+    "pg": "^8.11.0"
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,121 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+import * as docker from "@pulumi/docker";
+
+const config = new pulumi.Config();
+const nsName = config.require("studentNamespace");
+const dbPassword = config.getSecret("dbPassword") || pulumi.secret("password");
+
+const imageName = config.get("appImage") || `sample-form-app:${nsName}`;
+const registry = config.getObject<docker.ImageRegistry>("registry");
+
+// Build and push the application image
+const appImage = new docker.Image("app-image", {
+  build: "./app",
+  imageName: imageName,
+  registry: registry,
+});
+
+const namespace = new k8s.core.v1.Namespace(nsName, {
+  metadata: { name: nsName },
+});
+
+const postgresLabels = { app: "postgres" };
+const postgres = new k8s.apps.v1.Deployment("postgres", {
+  metadata: { namespace: namespace.metadata.name },
+  spec: {
+    selector: { matchLabels: postgresLabels },
+    template: {
+      metadata: { labels: postgresLabels },
+      spec: {
+        containers: [
+          {
+            name: "postgres",
+            image: "postgres:16",
+            env: [
+              { name: "POSTGRES_DB", value: "students" },
+              { name: "POSTGRES_USER", value: "user" },
+              { name: "POSTGRES_PASSWORD", value: dbPassword },
+            ],
+            ports: [{ containerPort: 5432 }],
+          },
+        ],
+      },
+    },
+  },
+});
+
+const postgresSvc = new k8s.core.v1.Service("postgres-svc", {
+  metadata: { namespace: namespace.metadata.name },
+  spec: {
+    selector: postgresLabels,
+    ports: [{ port: 5432 }],
+  },
+});
+
+const appLabels = { app: "web" };
+const appDeployment = new k8s.apps.v1.Deployment("web", {
+  metadata: { namespace: namespace.metadata.name },
+  spec: {
+    selector: { matchLabels: appLabels },
+    template: {
+      metadata: { labels: appLabels },
+      spec: {
+        containers: [
+          {
+            name: "web",
+            image: appImage.imageName,
+            env: [
+              { name: "DB_HOST", value: postgresSvc.metadata.name },
+              { name: "DB_USER", value: "user" },
+              { name: "DB_PASS", value: dbPassword.apply(p => p) },
+              { name: "DB_NAME", value: "students" },
+            ],
+            ports: [{ containerPort: 8080 }],
+          },
+        ],
+      },
+    },
+  },
+});
+
+const appSvc = new k8s.core.v1.Service("web-svc", {
+  metadata: { namespace: namespace.metadata.name },
+  spec: {
+    selector: appLabels,
+    ports: [{ port: 80, targetPort: 8080 }],
+  },
+});
+
+// Expose via OpenShift Route if available
+const route = new k8s.apiextensions.CustomResource("web-route", {
+  apiVersion: "route.openshift.io/v1",
+  kind: "Route",
+  metadata: { namespace: namespace.metadata.name },
+  spec: {
+    to: { kind: "Service", name: appSvc.metadata.name },
+    port: { targetPort: 8080 },
+  },
+});
+
+// Example RBAC
+const role = new k8s.rbac.v1.Role("web-role", {
+  metadata: { namespace: namespace.metadata.name },
+  rules: [
+    { apiGroups: [""], resources: ["configmaps"], verbs: ["get", "list"] },
+  ],
+});
+
+new k8s.rbac.v1.RoleBinding("web-rolebinding", {
+  metadata: { namespace: namespace.metadata.name },
+  subjects: [
+    { kind: "ServiceAccount", name: "default", namespace: namespace.metadata.name },
+  ],
+  roleRef: {
+    kind: "Role",
+    name: role.metadata.name,
+    apiGroup: "rbac.authorization.k8s.io",
+  },
+});
+
+export const appUrl = route.status.apply(s => `http://${s.ingress[0].host}`);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "workshop-sample",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.88.2",
+    "@pulumi/kubernetes": "^4.10.0",
+    "@pulumi/docker": "^3.4.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "bin"
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary
- create simple Node/Express form app with Postgres
- add Dockerfile to build the app
- set up Pulumi project using TypeScript
- deploy app and Postgres to a chosen namespace
- document setup steps in README

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685207bbd40c832da945ffde8e4fc010